### PR TITLE
get_optional_float should accept integers as well

### DIFF
--- a/lib/smartystreets/base_json_object.rb
+++ b/lib/smartystreets/base_json_object.rb
@@ -46,12 +46,12 @@ module SmartyStreets
     end
 
     def get_optional_float(hash, key)
-      hash[key] != nil ? check_type(hash[key], Float) : nil
+      hash[key] != nil ? check_type(hash[key], Float, Integer) : nil
     end
 
     def get_required_float(hash, key)
       check_argument(hash[key] != nil, -> { "#{key} was nil and should be a float"})
-      check_type(hash[key], Float)
+      check_type(hash[key], Float, Integer)
     end
 
     def get_optional_boolean(hash, key)


### PR DESCRIPTION
We ran into an edge case that the lat was returned as an exact integer. This broke the gem since the get_optional_float requires the `Float` type, but `-123.is_a?(Float) == false`. This fixes that edge case issue by allowing optional floats to be an integer too.